### PR TITLE
Use the compat version of checkSelfPermission() (fixes #28)

### DIFF
--- a/WallpaperPicker/src/com/fairphone/fplauncher3/WallpaperCropActivity.java
+++ b/WallpaperPicker/src/com/fairphone/fplauncher3/WallpaperCropActivity.java
@@ -40,6 +40,7 @@ import android.Manifest;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.v13.app.ActivityCompat;
 import android.util.Log;
 import android.view.Display;
 import android.view.View;
@@ -87,7 +88,7 @@ public class WallpaperCropActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (this.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
             this.requestPermissions(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, MY_PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE);
         } else {
             init();


### PR DESCRIPTION
Sorry, I should have done this in #14. I totally forgot the standard version of this function does not work on old Android versions.